### PR TITLE
Add team removal and renumbering to start page UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# .DS_Store
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]


### PR DESCRIPTION
Introduces a remove button for each team entry, allowing users to delete teams from the start page. Teams are renumbered sequentially after removal, and related logic is updated to support these changes. Also improves code formatting and consistency in the team entry management.